### PR TITLE
teleirc pull request - a small convenience update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "bugs": "https://github.com/FruitieX/teleirc/issues",
     "homepage": "https://github.com/FruitieX/teleirc",
     "dependencies": {
-        "irc": "~0.3.7"
+        "irc": "~0.3.12"
     }
 }

--- a/teleirc.js
+++ b/teleirc.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 var assert = require('assert');
-var config = require(process.env.HOME + '/.teleircTESTConfig.js');
+var config = require(process.env.HOME + '/.teleircConfig.js');
 
 // check that required config options are set
-var checkConfigMsg = ', check teleircTESTConfig.js.example for an example';
+var checkConfigMsg = ', check teleircConfig.js.example for an example';
 assert(config.server, 'config.server block missing' + checkConfigMsg);
 assert(config.server.address, 'config.server.address not set' + checkConfigMsg);
 assert(config.server.port, 'config.server.port not set' + checkConfigMsg);

--- a/teleirc.js
+++ b/teleirc.js
@@ -24,7 +24,7 @@ config.tgchat_nick = config.tgchat.replace(/\s+/, '_')
 var irc_client = new irc.Client(config.server.address, config.server.nick, {
     debug: config.server.debug,
     secure: config.server.secure,
-    passsword: config.server.password,
+    password: config.server.password,
     selfSigned: config.server.selfSigned,
     certExpired: config.server.certExpired,
     port: config.server.port,

--- a/teleirc.js
+++ b/teleirc.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 var assert = require('assert');
-var config = require(process.env.HOME + '/.teleircConfig.js');
+var config = require(process.env.HOME + '/.teleircTESTConfig.js');
 
 // check that required config options are set
-var checkConfigMsg = ', check teleircConfig.js.example for an example';
+var checkConfigMsg = ', check teleircTESTConfig.js.example for an example';
 assert(config.server, 'config.server block missing' + checkConfigMsg);
 assert(config.server.address, 'config.server.address not set' + checkConfigMsg);
 assert(config.server.port, 'config.server.port not set' + checkConfigMsg);
@@ -24,6 +24,7 @@ config.tgchat_nick = config.tgchat.replace(/\s+/, '_')
 var irc_client = new irc.Client(config.server.address, config.server.nick, {
     debug: config.server.debug,
     secure: config.server.secure,
+    passsword: config.server.password,
     selfSigned: config.server.selfSigned,
     certExpired: config.server.certExpired,
     port: config.server.port,

--- a/teleircConfig.js.example
+++ b/teleircConfig.js.example
@@ -7,8 +7,8 @@ var config = {};
 config.server = {
     'address': 'irc.quakenet.org',  // irc server address
     'port': 6667,                   // irc server port
-    'nick': 'TEST_TgBot',         // irc nick to use
-    'password': '?????',         // irc nick to use
+    'nick': 'exampleTgBot',         // irc nick to use
+    'password': '?????',            // irc password to use (requires manual nick registration before using this option, can be ignored)
     'chan': '#examplechan',         // irc channel to join
     'secure': false,                // use ssl when connecting?
     'selfSigned': false,            // accept self-signed certificates?

--- a/teleircConfig.js.example
+++ b/teleircConfig.js.example
@@ -7,7 +7,8 @@ var config = {};
 config.server = {
     'address': 'irc.quakenet.org',  // irc server address
     'port': 6667,                   // irc server port
-    'nick': 'exampleTgBot',         // irc nick to use
+    'nick': 'TEST_TgBot',         // irc nick to use
+    'password': '?????',         // irc nick to use
     'chan': '#examplechan',         // irc channel to join
     'secure': false,                // use ssl when connecting?
     'selfSigned': false,            // accept self-signed certificates?


### PR DESCRIPTION
#### Updated package.json
It now lists the most recent version of node-irc module (even though everything worked fine, I didn't like that NPM listed irc package as missing).
#### Password option:
There is now a new option in config: *'password'*. A user can go to irc server they want the bot to connect to, register a desired nick and use the nick/password combination in .teleircConfig.js. The bot will then automatically identify with NickServ after connecting. The registered nick cannot be taken by other users even when the bot is offline.

This option can be ignored.

