### PR TITLE
Move to node-telegram-bot-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "irc": "~0.3.12",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
-    "telegram-bot": "^0.2.0"
+    "node-telegram-bot-api": "^0.15.0"
   },
   "devDependencies": {
     "jscs": "^2.2.1",

--- a/tg.js
+++ b/tg.js
@@ -1,4 +1,4 @@
-var Telegram = require('telegram-bot');
+var Telegram = require('node-telegram-bot-api');
 var fs = require('fs');
 var irc = require('./irc');
 
@@ -55,8 +55,7 @@ var writeChatIds = function(config) {
 };
 
 module.exports = function(config, sendTo) {
-    var tg = new Telegram(config.tgToken);
-    tg.start();
+    var tg = new Telegram(config.tgToken,{polling: true});
 
     readChatIds(config.channels);
 


### PR DESCRIPTION
Move to node-telegram-bot-api because it supports image
functions and separates different messages better. 

This is just first step. We should use also those different types of messages like api reference suggest.