### PR TITLE
Add basic support for pictures

### DIFF
--- a/tg.js
+++ b/tg.js
@@ -92,8 +92,15 @@ module.exports = function(config, sendTo) {
         } else if (msg.document) {
             text = '(Document)';
         } else if (msg.photo) {
-            text = '(Image, ' + msg.photo.slice(-1)[0].width + 'x' +
-                                msg.photo.slice(-1)[0].height + ')';
+            var fileid = msg.photo[msg.photo.length - 1].file_id;
+            var promise = tg.getFileLink(fileid);
+            promise.then(function(path) {
+                console.log(path);
+                sendTo.irc(channel.ircChan, '<' + user + '>: ' + path);
+                return path;
+            });
+            return;
+
         } else if (msg.sticker) {
             text = '(Sticker)';
         } else if (msg.video) {


### PR DESCRIPTION
Add basic support for pictures posted to Telegram. Now it just
only pass the telegram url to irc. That url is valid only for 1h.
Next step is to make possible to save it to local http server
and send link to there. That should be optional as not everybody
have own server to run this.

Now the program crash if photo is send to telegram before
irc part is fully connected. We should consider to wait that before
accepting any messages from telegram.