### PR TITLE
Add nick to every line in irc when relaying multiline tg messages

### DIFF
--- a/tg.js
+++ b/tg.js
@@ -128,10 +128,11 @@ module.exports = function(config, sendTo) {
             msg.voice || msg.contact || msg.location) && !config.showMedia) {
             return;
         }
-
+        var text;
         if (msg.reply_to_message && msg.text) {
+            text = msg.text.replace(/\n/g , '\n<' + getName(msg.from, config) + '>: ');
             sendTo.irc(channel.ircChan, '<' + getName(msg.from, config) + '>: ' +
-                '@' + getName(msg.reply_to_message.from, config) + ', ' + msg.text);
+                '@' + getName(msg.reply_to_message.from, config) + ', ' + text);
         } else if (msg.audio) {
             sendTo.irc(channel.ircChan, '<' + getName(msg.from, config) + '>: ' +
                 '(Audio)');
@@ -181,7 +182,8 @@ module.exports = function(config, sendTo) {
             sendTo.irc(channel.ircChan, getName(msg.left_chat_participant, config) +
                 ' was removed by: ' + getName(msg.from, config));
         } else {
-            sendTo.irc(channel.ircChan, '<' + getName(msg.from, config) + '>: ' + msg.text);
+            text = msg.text.replace(/\n/g , '\n<' + getName(msg.from, config) + '>: ');
+            sendTo.irc(channel.ircChan, '<' + getName(msg.from, config) + '>: ' + text);
         }
     });
 


### PR DESCRIPTION
Previously multiline messages from Telegram showed up like this:

16:53:22      botnick <Olli>: mitä ihmiset on mieltä
16:53:23      botnick tämmösten monirivi
16:53:24      botnick viestien näkymisestä irkissä?

which is confusing. I added name to every line, like this:

21:10:49      botnick <Olli>: This looks
21:10:49      botnick <Olli>: much better