### PR TITLE
Fix topic change message

### DIFF
--- a/irc.js
+++ b/irc.js
@@ -83,7 +83,7 @@ module.exports = function(config, sendTo) {
             return;
         }
 
-        var text = '* Topic for channel ' + channel.chanAlias || channel.ircChan +
+        var text = '* Topic for channel ' + (channel.chanAlias || channel.ircChan) +
                    ':\n' + topic.split(' | ').join('\n') +
                    '\n* set by ' + nick.split('!')[0];
         sendTo.tg(channel, text);


### PR DESCRIPTION
This message was shown when someone changed the topic:

`* Topic for channel undefined`