### PR TITLE
Set IRC and/or Telegram Group as read-only, and override rule by highlighting bot

### DIFF
--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -80,6 +80,8 @@ config.replaceNewlines = ' … ';
 config.ircNick = 'tgBot';
 config.ircServer = 'irc.cs.hut.fi';
 
+config.telegramNick = 'tgBot';
+
 // array of commands to send to IRC server as soon as we're connected,
 // example: config.ircPerformCmds = [
 //     'PRIVMSG Q@CServe.quakenet.org :AUTH <username> <password>'
@@ -99,6 +101,14 @@ config.channels = [
         ircChan: '#channel2',
         chanPwd: 'passwd',
         tgGroup: 'Tg_Group_2'
+    },
+
+    // example of a readOnly IRC channel and Telegram Group:
+    {
+        ircChan: '#channel3',
+        ircChanReadOnly: true,
+        tgGroup: 'Tg_Group_3',
+        tgGroupReadOnly: true
     },
 
     // example of an IRC channel with an alias:

--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -106,9 +106,11 @@ config.channels = [
     // example of a readOnly IRC channel and Telegram Group:
     {
         ircChan: '#channel3',
-        ircChanReadOnly: true,
+        ircChanReadOnly: true,          /* Optional */
+        ircChanOverrideReadOnly: false, /* Optional - override readonly by highlighting the bot */
         tgGroup: 'Tg_Group_3',
-        tgGroupReadOnly: true
+        tgGroupReadOnly: true           /* Optional */
+        tgGroupOverrideReadOnly: false, /* Optional - same as ircChanOverrideReadOnly */
     },
 
     // example of an IRC channel with an alias:

--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -109,7 +109,7 @@ config.channels = [
         ircChanReadOnly: true,          /* Optional */
         ircChanOverrideReadOnly: false, /* Optional - override readonly by highlighting the bot */
         tgGroup: 'Tg_Group_3',
-        tgGroupReadOnly: true           /* Optional */
+        tgGroupReadOnly: true,          /* Optional */
         tgGroupOverrideReadOnly: false, /* Optional - same as ircChanOverrideReadOnly */
     },
 

--- a/src/irc/index.js
+++ b/src/irc/index.js
@@ -20,8 +20,15 @@ var init = function(msgCallback) {
 
     nodeIrc.on('message', function(user, chanName, text) {
         var message = ircUtil.parseMsg(chanName, text);
+        var channel = ircUtil.lookupChannel(chanName, config.channels);
+        var ircChanReadOnly = channel.ircChanReadOnly;
+        var isBotHighlighted = false;
 
         if (message) {
+            isBotHighlighted = message.text.startsWith(config.ircNick);
+        }
+
+        if ((message && !ircChanReadOnly) || (message && isBotHighlighted)) {
             logger.debug('got irc msg:', message);
             msgCallback({
                 protocol: 'irc',

--- a/src/irc/index.js
+++ b/src/irc/index.js
@@ -22,13 +22,18 @@ var init = function(msgCallback) {
         var message = ircUtil.parseMsg(chanName, text);
         var channel = ircUtil.lookupChannel(chanName, config.channels);
         var ircChanReadOnly = channel.ircChanReadOnly;
+        var isOverrideReadOnly = channel.ircChanOverrideReadOnly;
         var isBotHighlighted = false;
 
         if (message) {
             isBotHighlighted = message.text.startsWith(config.ircNick);
-        }
 
-        if ((message && !ircChanReadOnly) || (message && isBotHighlighted)) {
+            if (ircChanReadOnly) {
+                if (!(isOverrideReadOnly && isBotHighlighted)) {
+                    return;
+                }
+            }
+
             logger.debug('got irc msg:', message);
             msgCallback({
                 protocol: 'irc',

--- a/src/tg/index.js
+++ b/src/tg/index.js
@@ -22,7 +22,6 @@ var init = function(msgCallback) {
 
             tgUtil.parseMsg(msg, myUser, tg, function(message) {
                 var tgGroupReadOnly = message.channel.tgGroupReadOnly;
-                var text = msg.text;
                 var isBotHighlighted = false;
 
                 if (message) {

--- a/src/tg/index.js
+++ b/src/tg/index.js
@@ -22,13 +22,18 @@ var init = function(msgCallback) {
 
             tgUtil.parseMsg(msg, myUser, tg, function(message) {
                 var tgGroupReadOnly = message.channel.tgGroupReadOnly;
+                var isOverrideReadonly = message.channel.tgGroupOverrideReadOnly;
                 var isBotHighlighted = false;
 
                 if (message) {
                     isBotHighlighted = msg.text.startsWith('@' + myUser.username);
-                }
 
-                if ((message && !tgGroupReadOnly) || (message && isBotHighlighted)) {
+                    if (tgGroupReadOnly) {
+                        if (!(isOverrideReadonly && isBotHighlighted)) {
+                            return;
+                        }
+                    }
+
                     message.protocol = 'tg';
                     msgCallback(message);
                 }

--- a/src/tg/index.js
+++ b/src/tg/index.js
@@ -21,7 +21,15 @@ var init = function(msgCallback) {
             logger.debug('got tg msg:', msg);
 
             tgUtil.parseMsg(msg, myUser, tg, function(message) {
+                var tgGroupReadOnly = message.channel.tgGroupReadOnly;
+                var text = msg.text;
+                var isBotHighlighted = false;
+
                 if (message) {
+                    isBotHighlighted = msg.text.startsWith('@' + myUser.username);
+                }
+
+                if ((message && !tgGroupReadOnly) || (message && isBotHighlighted)) {
                     message.protocol = 'tg';
                     msgCallback(message);
                 }


### PR DESCRIPTION
Add feature that makes it possible to set either IRC channel or Teleg…ram Group as readonly, and only overriden by highlighting the bot. It required three new config parameters to be added to config.js boolean ircChanReadOnly, tgGroupReadOnly attributes inside config.ircOptions. And telegramNick to specify the telegram bot nickname (which previously lacked because unneeded I suppose).