### PR TITLE
hint for config argument, that full path is required

### DIFF
--- a/src/arguments.js
+++ b/src/arguments.js
@@ -5,7 +5,7 @@ module.exports = {
         .usage('Usage: $0 [options]')
 
         .alias('c', 'config')
-        .describe('c', 'Use config from given path')
+        .describe('c', 'Use config from given path. Always use full path e.g. /path/to/config.js')
 
         .alias('g', 'genconfig')
         .describe('g', 'Generate a new default config')


### PR DESCRIPTION
As discussed in #teleirc this updates the help message to provide a more explicit hint that when using an own config file always the full path as to be given