### PR TITLE
Add Imgur integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Optional:
   `/setcommands` BotFather command. You may copy-paste the contents of
   [`commands.txt`](/extras/commands.txt) to show all supported commands to
   Telegram clients.
+- Instead of enabling the HTTP server for serving sent media files, photo files
+  sent to the groups can be uploaded to [Imgur](http://imgur.com/). See the
+  [README for Imgur](extras/Imgur_README.md) for more information.
 
 Troubleshooting
 ---------------

--- a/extras/Imgur_README.md
+++ b/extras/Imgur_README.md
@@ -1,0 +1,15 @@
+Uploading photos with node-imgur
+--------------------------------
+
+If you aren't fond of setting up an own HTTP server for media files and you
+only need photos from the groups to IRC, Teleirc also offers integration with
+Imgur's API.
+
+In order to use the API, you need to
+[register to the API](https://api.imgur.com/endpoints). Uploading images
+requires authentication, so you need to select "OAuth 2 authorization without
+a callback URL" in the application registration. After you've registered, paste
+your client id from Imgur to `config.imgurClientId` in your config.js.
+
+After this, you can enable Imgur uploading by setting `config.uploadToImgur` to
+true.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/FruitieX/teleirc",
   "dependencies": {
     "git-rev-sync": "^1.6.0",
+    "imgur": "^0.2.0",
     "irc": "^0.5.0",
     "irc-colors": "^1.2.1",
     "lodash": "^4.12.0",

--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -37,6 +37,13 @@ config.httpPort = 9090;
 // HTTP server location, URLs are generated from this
 config.httpLocation = 'http://mydomain.com' + ':' + config.httpPort;
 
+// Upload sent photos to Imgur, links to Imgur uploads are
+// forwared to IRC
+config.uploadToImgur = false;
+
+// Imgur client id required for uploading photos to Imgur
+config.imgurClientId = 'YOUR-CLIENT-ID';
+
 // Whether to allow sending messages to IRC without nick prefix
 config.allowCommands = false;
 

--- a/src/tg/util.js
+++ b/src/tg/util.js
@@ -7,6 +7,12 @@ var osHomedir = require('os-homedir');
 var mkdirp = require('mkdirp');
 var crypto = require('crypto');
 var logger = require('winston');
+var imgur = require('imgur');
+var os = require('os');
+
+if (config.uploadToImgur) {
+  imgur.setClientId(config.imgurClientId);
+}
 
 var chatIdsPath = path.join(osHomedir(), '.teleirc');
 
@@ -101,6 +107,19 @@ exports.serveFile = function(fileId, config, tg, callback) {
         callback(config.httpLocation + '/' + randomString + '/' + path.basename(filePath));
     });
 };
+
+exports.uploadToImgur = function(fileId, config, tg, callback) {
+  var filesPath = os.tmpdir()
+  var randomString = exports.randomValueBase64(config.mediaRandomLength);
+  mkdirp(path.join(filesPath, randomString));
+  tg.downloadFile(fileId, path.join(filesPath, randomString))
+  .then(function(filePath) {
+    imgur.uploadFile(filePath)
+    .then(function(json) {
+      callback(json.data.link);
+    })
+  })
+}
 
 exports.initHttpServer = function() {
     var filesPath = path.join(osHomedir(), '.teleirc', 'files');
@@ -205,7 +224,11 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
     // skip posts containing media if it's configured off
     if ((msg.audio || msg.document || msg.photo || msg.sticker || msg.video ||
                 msg.voice || msg.contact || msg.location) && !config.showMedia) {
-        return callback();
+        // except if the media object is an photo and imgur uploading is
+        // enabled
+        if (!(msg.photo && config.uploadToImgur)) {
+          return callback();
+        }
     }
 
     var prefix = '';
@@ -305,25 +328,42 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
     } else if (msg.photo) {
         // pick the highest quality photo
         var photo = msg.photo[msg.photo.length - 1];
-
-        exports.serveFile(photo.file_id, config, tg, function(url) {
+        if (config.uploadToImgur) {
+          exports.uploadToImgur(photo.file_id, config, tg, function(url) {
             callback({
                 channel: channel,
                 text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
                     url + (msg.caption ? ' ' + msg.caption : '')
             });
-        });
+          });
+        } else {
+          exports.serveFile(photo.file_id, config, tg, function(url) {
+              callback({
+                  channel: channel,
+                  text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
+                      url + (msg.caption ? ' ' + msg.caption : '')
+              })
+          });
+        }
     } else if (msg.new_chat_photo) {
         // pick the highest quality photo
         var chatPhoto = msg.new_chat_photo[msg.new_chat_photo.length - 1];
-
-        exports.serveFile(chatPhoto.file_id, config, tg, function(url) {
-            callback({
-                channel: channel,
-                text: prefix + '(New chat photo, ' +
-                        chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
-            });
-        });
+        if (config.uploadToImgur) {
+          exports.uploadToImgur(chatPhoto.file_id, config, tg, function(url) {
+              callback({
+                  channel: channel,
+                  text: prefix + '(New chat photo, ' +
+                          chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
+              })});
+        } else {
+          exports.serveFile(chatPhoto.file_id, config, tg, function(url) {
+              callback({
+                  channel: channel,
+                  text: prefix + '(New chat photo, ' +
+                          chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
+              });
+          });
+        }
     } else if (msg.sticker) {
         exports.serveFile(msg.sticker.file_id, config, tg, function(url) {
             callback({

--- a/src/tg/util.js
+++ b/src/tg/util.js
@@ -11,7 +11,7 @@ var imgur = require('imgur');
 var os = require('os');
 
 if (config.uploadToImgur) {
-  imgur.setClientId(config.imgurClientId);
+    imgur.setClientId(config.imgurClientId);
 }
 
 var chatIdsPath = path.join(osHomedir(), '.teleirc');
@@ -109,17 +109,17 @@ exports.serveFile = function(fileId, config, tg, callback) {
 };
 
 exports.uploadToImgur = function(fileId, config, tg, callback) {
-  var filesPath = os.tmpdir()
-  var randomString = exports.randomValueBase64(config.mediaRandomLength);
-  mkdirp(path.join(filesPath, randomString));
-  tg.downloadFile(fileId, path.join(filesPath, randomString))
-  .then(function(filePath) {
-    imgur.uploadFile(filePath)
-    .then(function(json) {
-      callback(json.data.link);
-    })
-  })
-}
+    var filesPath = os.tmpdir();
+    var randomString = exports.randomValueBase64(config.mediaRandomLength);
+    mkdirp(path.join(filesPath, randomString));
+    tg.downloadFile(fileId, path.join(filesPath, randomString))
+    .then(function(filePath) {
+            imgur.uploadFile(filePath)
+            .then(function(json) {
+                callback(json.data.link);
+            });
+        });
+};
 
 exports.initHttpServer = function() {
     var filesPath = path.join(osHomedir(), '.teleirc', 'files');
@@ -227,7 +227,7 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
         // except if the media object is an photo and imgur uploading is
         // enabled
         if (!(msg.photo && config.uploadToImgur)) {
-          return callback();
+            return callback();
         }
     }
 
@@ -329,40 +329,40 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
         // pick the highest quality photo
         var photo = msg.photo[msg.photo.length - 1];
         if (config.uploadToImgur) {
-          exports.uploadToImgur(photo.file_id, config, tg, function(url) {
-            callback({
-                channel: channel,
-                text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
+            exports.uploadToImgur(photo.file_id, config, tg, function(url) {
+                callback({
+                    channel: channel,
+                    text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
                     url + (msg.caption ? ' ' + msg.caption : '')
+                });
             });
-          });
         } else {
-          exports.serveFile(photo.file_id, config, tg, function(url) {
-              callback({
-                  channel: channel,
-                  text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
-                      url + (msg.caption ? ' ' + msg.caption : '')
-              })
-          });
+            exports.serveFile(photo.file_id, config, tg, function(url) {
+                callback({
+                    channel: channel,
+                    text: prefix + '(Photo, ' + photo.width + 'x' + photo.height + ') ' +
+                    url + (msg.caption ? ' ' + msg.caption : '')
+                });
+            });
         }
     } else if (msg.new_chat_photo) {
         // pick the highest quality photo
         var chatPhoto = msg.new_chat_photo[msg.new_chat_photo.length - 1];
         if (config.uploadToImgur) {
-          exports.uploadToImgur(chatPhoto.file_id, config, tg, function(url) {
-              callback({
-                  channel: channel,
-                  text: prefix + '(New chat photo, ' +
-                          chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
-              })});
+            exports.uploadToImgur(chatPhoto.file_id, config, tg, function(url) {
+                callback({
+                    channel: channel,
+                    text: prefix + '(New chat photo, ' +
+                    chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
+                });});
         } else {
-          exports.serveFile(chatPhoto.file_id, config, tg, function(url) {
-              callback({
-                  channel: channel,
-                  text: prefix + '(New chat photo, ' +
-                          chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
-              });
-          });
+            exports.serveFile(chatPhoto.file_id, config, tg, function(url) {
+                callback({
+                    channel: channel,
+                    text: prefix + '(New chat photo, ' +
+                    chatPhoto.width + 'x' + chatPhoto.height + ') ' + url
+                });
+            });
         }
     } else if (msg.sticker) {
         exports.serveFile(msg.sticker.file_id, config, tg, function(url) {


### PR DESCRIPTION
Few HY CS Department based communities have started to use Teleirc for those people who still think that IRC is the best thing ever. 🔥

Since hosting an HTTP server isn't for everyone, I decided to do something about #142.

This pull request adds a feature that uploads photos from Telegram groups to Imgur and sends the URL to their IRC channels. It uses [node-imgur](https://github.com/kaimallea/node-imgur) for communicating with Imgur's API. Using the API requires registration.

This PR doesn't include anything about the feature (how to enable it and so on) in README.md, but I could write something before merging if this feels like a good addition to the bot.