### PR TITLE
.travis.yml: use NOTICE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 notifications:
     irc:
         on_success: change
+        use_notice: true
         channels:
             # Avoid forks spamming the channel.
             # travis encrypt "ircs://irc.freenode.net:6697/#teleirc" -r FruitieX/teleirc


### PR DESCRIPTION
I think NOTICEs should be used as the RFC suggests bots to use it and
there are users from Matrix where the IRC bridge converts NOTICEs to
m.notice and detects them to be messages from bots and doesn't ping
people by default.