### PR TITLE
Add Option to Turn Off Emphasized Actions

### DIFF
--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -158,3 +158,6 @@ config.hlRegexp = new RegExp(regex, 'i');
 // with the default regexp this would hide the bot nickname in messages when
 // highlighted
 config.hlOnlyShowMatch = false;
+
+// put action messages (posted with /me in IRC) between '*'
+config.emphasizeAction = true;

--- a/src/irc/index.js
+++ b/src/irc/index.js
@@ -118,12 +118,17 @@ var init = function(msgCallback) {
         var message = ircUtil.parseMsg(chanName, text);
 
         if (message) {
+            var messageText = user + ': ' + message.text;
+            if (config.emphasizeAction) {
+                messageText = '*' + messageText + '*';
+            }
+
             msgCallback({
                 protocol: 'irc',
                 type: 'action',
                 channel: message.channel,
                 user: null,
-                text: '*' + user + ': ' + message.text + '*'
+                text: messageText
             });
         }
     });


### PR DESCRIPTION
If a `/me` action ends with a link (e. g. when posting files via Matrix to IRC), the `*` at the end of the message breaks the link. This PR adds an option to turn off emphasizing actions.