### PR TITLE
Add the ability to automatically convert WebP or other file types

### DIFF
--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -22,6 +22,13 @@ config.relayIRCEvents = ['message', 'notice', 'action', 'topic', 'kick'];
 // forwarded to IRC
 config.showMedia = false;
 
+// Convert these media files to other types using the "convert" command.
+// To be able to convert from WebP, install imagemagick and the dwebp tool
+// (e.g. sudo apt install imagemagick webp)
+config.mediaConversions = {
+    //'webp': 'png'
+};
+
 // Add some randomness to url when relaying media
 // Use 0 to disable
 config.mediaRandomLength = 8;


### PR DESCRIPTION
Since .webp files (stickers) don't seem to open properly in most browsers, I added this configurable feature to automatically convert them to .png (or any other type, though .jpg failed to handle transparency in my tests).