### PR TITLE
Show snippets of original message in replies (Issue #62)

### DIFF
--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -18,6 +18,10 @@ config.tgToken = 'YOUR-BOT-TOKEN';
 // message, notice, action, topic, join, part, kick, quit
 config.relayIRCEvents = ['message', 'notice', 'action', 'topic', 'kick'];
 
+// The maximum length of quoted message when a message is replied to in Telegram
+// Set to 0 to disable showing replies
+config.replySnippetLength = 80;
+
 // enable HTTP server which hosts sent media files, links to files are
 // forwarded to IRC
 config.showMedia = false;

--- a/src/tg/util.js
+++ b/src/tg/util.js
@@ -336,9 +336,19 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
             replyName = exports.getName(msg.reply_to_message.from, config);
         }
 
+        // Show snippet of message being replied to
+        var snippet = '';
+        if (config.replySnippetLength) {
+            truncatedMessage = msg.reply_to_message.text.substr(0, config.replySnippetLength);
+            if (truncatedMessage.length < msg.reply_to_message.text.length) {
+                truncatedMessage = truncatedMessage + ' …';
+            }
+            snippet = ' [' + truncatedMessage + ']';
+        }
+
         callback({
             channel: channel,
-            text: prefix + '@' + replyName + ', ' + msg.text
+            text: prefix + '@' + replyName + snippet + ', ' + msg.text
         });
     } else if ((msg.forward_from || msg.forward_from_chat) && msg.text) {
         var from = msg.forward_from || msg.forward_from_chat;

--- a/src/tg/util.js
+++ b/src/tg/util.js
@@ -339,7 +339,9 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
         // Show snippet of message being replied to
         var snippet = '';
         if (config.replySnippetLength) {
-            truncatedMessage = msg.reply_to_message.text.substr(0, config.replySnippetLength);
+            truncatedMessage = msg.reply_to_message.text
+                               .substr(0, config.replySnippetLength)
+                               .trim();
             if (truncatedMessage.length < msg.reply_to_message.text.length) {
                 truncatedMessage = truncatedMessage + ' …';
             }


### PR DESCRIPTION
Here's my initial implementation. Let me know what you think and what needs changing. Maybe the config variable name and default value should be different?
Replies are shown like this:
`14:14          tg| <Me> @SomeoneElse ["Ståhlberg. Tasavallan ensimmäinen presidentti ei  …], Hieno mies!`