### PR TITLE
strip control codes

### DIFF
--- a/src/tg/index.js
+++ b/src/tg/index.js
@@ -71,7 +71,10 @@ var init = function(msgCallback) {
             }
 
             logger.verbose('>> relaying to TG:', message.text);
-            tg.sendMessage(message.channel.tgChatId, message.text);
+            tg.sendMessage(
+                message.channel.tgChatId,
+                tgUtil.stripIrcCodes(message.text)
+            );
         }
     };
 };

--- a/src/tg/util.js
+++ b/src/tg/util.js
@@ -483,3 +483,9 @@ exports.parseMsg = function(msg, myUser, tg, callback) {
         callback();
     }
 };
+
+exports.stripIrcCodes = function(text) {
+    return text.replace(
+        /\x03[0-9][0-9]?(?:,[0-9][0-9]?)?|[\x02\x03\x0f\x16\x1d\x1f]/g, ''
+    );
+};


### PR DESCRIPTION
color codes like \00301some text will show up as 01some text in telegram. this just adds a util function that strips all that.