### PR TITLE
Implement private messaging

### DIFF
--- a/src/irc/index.js
+++ b/src/irc/index.js
@@ -65,10 +65,16 @@ var init = function(msgCallback) {
             return;
         }
 
-        var message = ircUtil.parseMsg(chanName, text);
+        var userName = '';
+        if (chanName.toLowerCase() === nodeIrc.user.nick.toLowerCase()) {
+            chanName = config.ircNick;
+            userName = user;
+        }
+
+        var message = ircUtil.parseMsg2(chanName, userName, text);
 
         if (message) {
-            var channel = ircUtil.lookupChannel(chanName, config.channels);
+            var channel = ircUtil.lookupChannel2(chanName, userName, config.channels);
             var ircChanReadOnly = channel.ircChanReadOnly;
             var isOverrideReadOnly = channel.ircChanOverrideReadOnly;
             var isBotHighlighted = config.hlRegexp.exec(message.text);
@@ -106,10 +112,16 @@ var init = function(msgCallback) {
             return;
         }
 
-        var notice = ircUtil.parseMsg(chanName, text);
+        var userName = '';
+        if (chanName.toLowerCase() === nodeIrc.user.nick.toLowerCase()) {
+            chanName = config.ircNick;
+            userName = user;
+        }
+
+        var notice = ircUtil.parseMsg2(chanName, userName, text);
 
         if (notice) {
-            var channel = ircUtil.lookupChannel(chanName, config.channels);
+            var channel = ircUtil.lookupChannel2(chanName, userName, config.channels);
             var ircChanReadOnly = channel.ircChanReadOnly;
             var isOverrideReadOnly = channel.ircChanOverrideReadOnly;
             var isBotHighlighted = config.hlRegexp.exec(notice.text);
@@ -144,7 +156,13 @@ var init = function(msgCallback) {
         var chanName = event.target;
         var text = event.message;
 
-        var message = ircUtil.parseMsg(chanName, text);
+        var userName = '';
+        if (chanName.toLowerCase() === nodeIrc.user.nick.toLowerCase()) {
+            chanName = config.ircNick;
+            userName = user;
+        }
+
+        var message = ircUtil.parseMsg2(chanName, userName, text);
 
         if (message) {
             var messageText = user + ': ' + message.text;
@@ -245,6 +263,13 @@ var init = function(msgCallback) {
     // new framework doesn't provide the channels....
     nodeIrc.on('quit', function(user, text, channels, message) {
         return;
+    });
+
+    nodeIrc.on('nick', function(event) {
+        if (nodeIrc.user.nick === event.nick) {
+            logger.debug('new nick:', event.new_nick);
+            nodeIrc.user.nick = event.new_nick;
+        }
     });
 
     // added since framework does not have async

--- a/src/irc/util.js
+++ b/src/irc/util.js
@@ -12,8 +12,9 @@ exports.lookupChannel2 = function(chanName, user, channels) {
         var channel = channels.filter(function(channel) {
             return channel.ircChan.toLowerCase() === user.toLowerCase();
         })[0];
-        if (channel)
+        if (channel) {
             return channel;
+        }
     }
     return channels.filter(function(channel) {
         return channel.ircChan.toLowerCase() === chanName.toLowerCase();

--- a/src/irc/util.js
+++ b/src/irc/util.js
@@ -7,8 +7,36 @@ exports.lookupChannel = function(chanName, channels) {
     })[0];
 };
 
+exports.lookupChannel2 = function(chanName, user, channels) {
+    if (user) {
+        var channel = channels.filter(function(channel) {
+            return channel.ircChan.toLowerCase() === user.toLowerCase();
+        })[0];
+        if (channel)
+            return channel;
+    }
+    return channels.filter(function(channel) {
+        return channel.ircChan.toLowerCase() === chanName.toLowerCase();
+    })[0];
+};
+
 exports.parseMsg = function(chanName, text) {
     var channel = exports.lookupChannel(chanName, config.channels);
+    if (!channel) {
+        logger.error('channel ' + chanName + ' not found in config!');
+        return;
+    }
+
+    text = text.trim();
+
+    return {
+        channel: channel,
+        text: text
+    };
+};
+
+exports.parseMsg2 = function(chanName, user, text) {
+    var channel = exports.lookupChannel2(chanName, user, config.channels);
     if (!channel) {
         logger.error('channel ' + chanName + ' not found in config!');
         return;


### PR DESCRIPTION
Implement simple private messaging support:

1. `{
    ircChan: 'bot',
    tgGroup: 'tg_username'
}`
IRC contact->bot messages will be forwarded to TG as tg_bot->tg_username.
Replies to that messages will be forwarded back to IRC contact, IRC name prefixing should be enabled.

2. `{
    ircChan: 'contact',
    tgGroup: 'tg_group'
}`
IRC contact->bot messages will be forwarded to TG as tg_bot->tg_group.
Messages from tg_group will be forwarded back to IRC contact.
