### PR TITLE
Add basic support for multiserver

### DIFF
--- a/src/config.defaults.js
+++ b/src/config.defaults.js
@@ -144,7 +144,14 @@ config.channels = [
         ircChan: '!XXXXXchannel3',
         chanAlias: '!channel3',
         tgGroup: 'Tg_Group_3'
-    }
+    },
+
+    // example of multiserver
+    {
+        ircChan: '#channel4',
+        tgGroup: 'Tg_Group_4',
+        ircServer: "irc.oftc.net"
+    },
 ];
 
 // see https://node-irc.readthedocs.org/en/latest/API.html#client for

--- a/src/irc/util.js
+++ b/src/irc/util.js
@@ -21,8 +21,8 @@ exports.lookupChannel2 = function(chanName, user, channels) {
     })[0];
 };
 
-exports.parseMsg = function(chanName, text) {
-    var channel = exports.lookupChannel(chanName, config.channels);
+exports.parseMsg = function(chanName, text, channels) {
+    var channel = exports.lookupChannel(chanName, channels);
     if (!channel) {
         logger.error('channel ' + chanName + ' not found in config!');
         return;
@@ -36,8 +36,8 @@ exports.parseMsg = function(chanName, text) {
     };
 };
 
-exports.parseMsg2 = function(chanName, user, text) {
-    var channel = exports.lookupChannel2(chanName, user, config.channels);
+exports.parseMsg2 = function(chanName, user, text, channels) {
+    var channel = exports.lookupChannel2(chanName, user, channels);
     if (!channel) {
         logger.error('channel ' + chanName + ' not found in config!');
         return;
@@ -63,8 +63,8 @@ exports.topicFormat = function(channel, topic, user) {
 
 };
 
-exports.parseTopic = function(chanName, topic, user) {
-    var channel = exports.lookupChannel(chanName, config.channels);
+exports.parseTopic = function(chanName, topic, user, channels) {
+    var channel = exports.lookupChannel(chanName, channels);
     if (!channel) {
         return;
     }


### PR DESCRIPTION
This adds support for basic muliserver setup.

This does not have support for different ports, nick or other server
configurations just yet. This only sets up basic muliserver setup using
one common ircOptions.

This does not modify the config structure, it only adds the option to
set server in config.channels, if ircServer is not set in
config.channels entrys it will default to config.ircServer.